### PR TITLE
add eth gas station api

### DIFF
--- a/ethgas/station.go
+++ b/ethgas/station.go
@@ -1,0 +1,111 @@
+package ethgas
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+// ETH Gas Station API - https://ethgasstation.info/
+//
+// Sample usage:
+//
+// station := &ethgas.Station{Timeout: time.Second * 10}
+// latest, err := station.Latest()
+// predictions, err := station.PredictionTable()
+type Station struct {
+	Timeout time.Duration
+	Debug   bool
+}
+
+type StationLatest struct {
+	Fast        float64
+	Fastest     float64
+	SafeLow     float64
+	Average     float64
+	BlockTime   float64 `json:"block_time"`
+	BlockNum    int64
+	Speed       float64
+	SafeLowWait float64
+	AvgWait     float64
+	FastWait    float64
+	FastestWait float64
+}
+
+func (s *Station) Latest() (*StationLatest, error) {
+	r, err := http.NewRequest("GET", "https://ethgasstation.info/json/ethgasAPI.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	w, err := s.fetch(r)
+	if err != nil {
+		return nil, err
+	}
+	var latest StationLatest
+	err = s.parse(w, &latest)
+	if err != nil {
+		return nil, err
+	}
+	return &latest, nil
+}
+
+type StationPrediction struct {
+	GasPrice            float64
+	HashPowerAccepting  float64 `json:"hashpower_accepting"`
+	HashPowerAccepting2 float64 `json:"hashpower_accepting2"`
+	TxAtAbove           float64 `json:"tx_atabove"`
+	Age                 interface{}
+	PctRemaining5m      float64 `json:"pct_remaining5m"`
+	PctMined5m          float64 `json:"pct_mined_5m"`
+	TotalSeen5m         float64 `json:"total_seen_5m"`
+	Average             float64
+	SafeLow             float64
+	NoMine              interface{}
+	AvgDiff             float64
+	Intercept           float64
+	HPACoef             float64 `json:"hpa_coef"`
+	AvgDiffCoef         float64 `json:"avgdiff_coef"`
+	TxAtAboveCoef       float64 `json:"tx_atabove_coef"`
+	Int2                float64
+	HPACoef2            float64 `json:"hpa_coef2"`
+	Sum                 float64
+	ExpectedWait        float64
+	Unsafe              int8
+	ExpectedTime        float64
+}
+
+func (s *Station) PredictionTable() ([]*StationPrediction, error) {
+	r, err := http.NewRequest("GET", "https://ethgasstation.info/json/predictTable.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	w, err := s.fetch(r)
+	if err != nil {
+		return nil, err
+	}
+	var table []*StationPrediction
+	err = s.parse(w, &table)
+	if err != nil {
+		return nil, err
+	}
+	return table, nil
+}
+
+func (s *Station) parse(w *http.Response, v interface{}) error {
+	body, err := ioutil.ReadAll(w.Body)
+	if err != nil {
+		return err
+	}
+	if s.Debug {
+		log.Printf("ETH Gas Station: %s", body)
+	}
+	return json.Unmarshal(body, v)
+}
+
+func (s *Station) fetch(r *http.Request) (*http.Response, error) {
+	ctx, _ := context.WithTimeout(r.Context(), s.Timeout)
+	return http.DefaultClient.Do(r.WithContext(ctx))
+}

--- a/ethgas/station_test.go
+++ b/ethgas/station_test.go
@@ -1,0 +1,68 @@
+package ethgas
+
+import (
+	"encoding/json"
+	"github.com/go-test/deep"
+	"testing"
+	"time"
+)
+
+func TestParseLatest(t *testing.T) {
+	body := `{"fast": 100.0, "fastest": 200.0, "safeLow": 13.0, "average": 30.0, "block_time": 11.76923076923077, "blockNum": 8355683, "speed": 0.9989258227743392, "safeLowWait": 14.0, "avgWait": 1.9, "fastWait": 0.4, "fastestWait": 0.4}`
+	want := StationLatest{Fast: 100, Fastest: 200, SafeLow: 13, Average: 30, BlockTime: 11.76923076923077, BlockNum: 8355683, Speed: 0.9989258227743392, SafeLowWait: 14, AvgWait: 1.9, FastWait: 0.4, FastestWait: 0.4}
+	var have StationLatest
+	err := json.Unmarshal([]byte(body), &have)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%# v", have)
+	if diff := deep.Equal(want, have); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestStationLatest(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	s := &Station{
+		Timeout: time.Second * 10,
+		Debug:   true,
+	}
+	latest, err := s.Latest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%# v", latest)
+}
+
+func TestParsePredictionTable(t *testing.T) {
+	body := `[{"gasprice": 0.01, "hashpower_accepting": 97.9797979798, "hashpower_accepting2": 66.2337662338, "tx_atabove": 445.0, "age": null, "pct_remaining5m":25.0, "pct_mined_5m": 100.0, "total_seen_5m": 1.0, "average": 1050, "safelow": 100, "nomine": null, "avgdiff": 1, "intercept": 4.8015, "hpa_coef": -0.0243, "avgdiff_coef": -1.6459, "tx_atabove_coef": 0.0006, "int2": 6.9238, "hpa_coef2": -0.067, "sum": 6.9238, "expectedWait": 1000.0, "unsafe": 1, "expectedTime": 185.42}]`
+	want := []*StationPrediction{
+		&StationPrediction{GasPrice: 0.01, HashPowerAccepting: 97.9797979798, HashPowerAccepting2: 66.2337662338, TxAtAbove: 445, Age: nil, PctRemaining5m: 25, PctMined5m: 100, TotalSeen5m: 1, Average: 1050, SafeLow: 100, NoMine: nil, AvgDiff: 1, Intercept: 4.8015, HPACoef: -0.0243, AvgDiffCoef: -1.6459, TxAtAboveCoef: 0.0006, Int2: 6.9238, HPACoef2: -0.067, Sum: 6.9238, ExpectedWait: 1000, Unsafe: 1, ExpectedTime: 185.42},
+	}
+	var have []*StationPrediction
+	err := json.Unmarshal([]byte(body), &have)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%# v", have[0])
+	if diff := deep.Equal(want, have); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestStationPredictionTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	s := &Station{
+		Timeout: time.Second * 10,
+		Debug:   true,
+	}
+	predictions, err := s.PredictionTable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%# v", predictions[0])
+}


### PR DESCRIPTION
Implements the two ETH Gas Station endpoints:

https://docs.ethgasstation.info/

Example:

```go
station := ethgas.Station{
    Timeout: time.Second * 10,
}
latest, err := station.Latest()
if err != nil {
    panic(err)
}
// From API Docs - Note: To convert the provided values to gwei, divide by 10
fast := int64(latest.Fast / 10)
standard := int64(latest.Average / 10)
safeLow := int64(latest.SafeLow / 10)
```