### PR TITLE
add price ticker for polling jsonrpc service for gas price

### DIFF
--- a/ethgas/priceticker.go
+++ b/ethgas/priceticker.go
@@ -1,0 +1,71 @@
+package ethgas
+
+import (
+	"context"
+	"math/big"
+	"time"
+)
+
+type Price struct {
+	Wei  *big.Int
+	Time time.Time
+}
+
+type PriceTickerParams struct {
+	JSONRPC JSONRPC
+	Timeout time.Duration
+	Errc    chan<- error
+}
+
+type JSONRPC interface {
+	SuggestGasPrice(context.Context) (*big.Int, error)
+}
+
+func NewPriceTicker(interval time.Duration, params PriceTickerParams) *PriceTicker {
+	prices := make(chan Price)
+	ticker := time.NewTicker(interval)
+	pt := &PriceTicker{
+		P:       prices,
+		ticker:  ticker,
+		jsonrpc: params.JSONRPC,
+		timeout: params.Timeout,
+		errc:    params.Errc,
+	}
+	go func() {
+		for now := range ticker.C {
+			pt.tick(now, prices)
+		}
+		close(prices)
+	}()
+	return pt
+}
+
+type PriceTicker struct {
+	P       <-chan Price
+	ticker  *time.Ticker
+	jsonrpc JSONRPC
+	timeout time.Duration
+	errc    chan<- error
+}
+
+func (pt *PriceTicker) tick(now time.Time, prices chan<- Price) {
+	ctx := context.Background()
+	if pt.timeout > 0 {
+		ctx, _ = context.WithTimeout(ctx, pt.timeout)
+	}
+	wei, err := pt.jsonrpc.SuggestGasPrice(ctx)
+	if err != nil {
+		// Avoid blocking on error channel
+		select {
+		case pt.errc <- err:
+		default:
+		}
+		return
+	}
+	price := Price{Wei: wei, Time: now}
+	prices <- price
+}
+
+func (pt *PriceTicker) Stop() {
+	pt.ticker.Stop()
+}

--- a/ethgas/priceticker_test.go
+++ b/ethgas/priceticker_test.go
@@ -1,0 +1,72 @@
+package ethgas
+
+import (
+	"context"
+	"github.com/go-test/deep"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type mockClient struct {
+	prices []*big.Int
+	pos    int
+	err    error
+}
+
+func (c *mockClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	price := c.prices[c.pos]
+	c.pos = (c.pos + 1) % len(c.prices)
+	return price, nil
+}
+
+func TestPriceTicker(t *testing.T) {
+	client := &mockClient{
+		prices: []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+		},
+	}
+	errc := make(chan error)
+	ticker := NewPriceTicker(time.Microsecond, PriceTickerParams{
+		JSONRPC: client,
+		Errc:    errc,
+	})
+	var prices []*big.Int
+	for i := 0; i < 3; i++ {
+		select {
+		case price := <-ticker.P:
+			if price.Time.IsZero() {
+				t.Errorf("expected populated time field")
+			}
+			prices = append(prices, price.Wei)
+		case err := <-errc:
+			t.Fatal(err)
+		}
+	}
+	ticker.Stop()
+	if diff := deep.Equal(client.prices, prices); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestPriceTickerTimeout(t *testing.T) {
+	client := &mockClient{
+		err: context.DeadlineExceeded,
+	}
+	errc := make(chan error)
+	ticker := NewPriceTicker(time.Microsecond, PriceTickerParams{
+		JSONRPC: client,
+		Errc:    errc,
+	})
+	select {
+	case <-ticker.P:
+		t.Fatal("expected error on errc channel")
+	case <-errc:
+		ticker.Stop()
+	}
+}


### PR DESCRIPTION
PriceTicker for polling JSONRPC for prices. 

Example usage:

```go
errc := make(chan error)
ticker := ethgas.NewPriceTicker(time.Second * 5, ethgas.PriceTickerParams{
    JSONRPC: ethClient,
    Timeout: time.Second * 3,
    Errc: errc,
})
for {
    select {
    case price := <- ticker.P:
        log.Printf("%v: %v", price.Time, price.Wei)
    case err := <- errc:
        panic(err)
    }
}
```