### PR TITLE
Added tests and fixed potential bug in hdnode

### DIFF
--- a/ethwallet/hdnode.go
+++ b/ethwallet/hdnode.go
@@ -231,11 +231,11 @@ func derivePrivateKey(masterKey *hdkeychain.ExtendedKey, path accounts.Derivatio
 	}
 
 	privateKey, err := key.ECPrivKey()
-	privateKeyECDSA := privateKey.ToECDSA()
 	if err != nil {
 		return nil, err
 	}
 
+	privateKeyECDSA := privateKey.ToECDSA()
 	return privateKeyECDSA, nil
 }
 

--- a/ethwallet/hdnode_test.go
+++ b/ethwallet/hdnode_test.go
@@ -62,7 +62,7 @@ func TestHDNodeDerivationFailsWithInvalidMnemonic(t *testing.T) {
 		"outdoor outdoor sentence roast truly flower surface power begin ocean silent debate funny",
 
 		// invalid checksum word
-		"shove crane auction quote tomorrow chalk repeat faint virtual ivory clown library flower mechanic shove",
+		"outdoor sentence roast truly flower surface power begin ocean silent debate outdoor",
 	}
 
 	for _, mnemonic := range testInvalidMnemonics {

--- a/ethwallet/hdnode_test.go
+++ b/ethwallet/hdnode_test.go
@@ -59,12 +59,15 @@ func TestHDNodeDerivationFailsWithInvalidMnemonic(t *testing.T) {
 		"wahgwaan sentence roast truly flower surface power begin ocean silent debate funny",
 
 		// one word too long
-		"outdoor sentence roast truly flower surface power begin ocean silent debate funny funny",
+		"outdoor outdoor sentence roast truly flower surface power begin ocean silent debate funny",
+
+		// invalid checksum word
+		"shove crane auction quote tomorrow chalk repeat faint virtual ivory clown library flower mechanic shove",
 	}
 
 	for _, mnemonic := range testInvalidMnemonics {
 		hdnode, err := ethwallet.NewHDNodeFromMnemonic(mnemonic, nil)
-		assert.Errorf(t, err, "Expected error for invalid mnemonic %v", mnemonic)
-		assert.Nilf(t, hdnode, "Expected nil hdnode for invalid mnemonic %v", mnemonic)
+		assert.Errorf(t, err, "Expected error for invalid mnemonic '%v'", mnemonic)
+		assert.Nilf(t, hdnode, "Expected nil hdnode for invalid mnemonic '%v'", mnemonic)
 	}
 }

--- a/ethwallet/hdnode_test.go
+++ b/ethwallet/hdnode_test.go
@@ -39,6 +39,7 @@ func TestHDNodeDerivationPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, hdnode)
 	assert.Equal(t, "0xe0C9828dee3411A28CcB4bb82a18d0aAd24489E0", hdnode.Address().Hex())
+	assert.Equal(t, testMnemonic, hdnode.Mnemonic())
 
 	err = hdnode.DeriveAccountIndex(1)
 	assert.NoError(t, err)
@@ -47,4 +48,23 @@ func TestHDNodeDerivationPath(t *testing.T) {
 	err = hdnode.DeriveAccountIndex(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "0xe0C9828dee3411A28CcB4bb82a18d0aAd24489E0", hdnode.Address().Hex())
+}
+
+func TestHDNodeDerivationFailsWithInvalidMnemonic(t *testing.T) {
+	testInvalidMnemonics := []string{
+		// one word too short
+		"sentence roast truly flower surface power begin ocean silent debate funny",
+
+		// first word is jamaican patois, not valid bip39 word
+		"wahgwaan sentence roast truly flower surface power begin ocean silent debate funny",
+
+		// one word too long
+		"outdoor sentence roast truly flower surface power begin ocean silent debate funny funny",
+	}
+
+	for _, mnemonic := range testInvalidMnemonics {
+		hdnode, err := ethwallet.NewHDNodeFromMnemonic(mnemonic, nil)
+		assert.Errorf(t, err, "Expected error for invalid mnemonic %v", mnemonic)
+		assert.Nilf(t, hdnode, "Expected nil hdnode for invalid mnemonic %v", mnemonic)
+	}
 }


### PR DESCRIPTION
Hi,

I found an instance at https://github.com/arcadeum/ethkit/blob/81456b5b8a62c4aeceba31bf307f7e4e9f9ba383/ethwallet/hdnode.go#L234 where `privateKey.ToECDSA()` is called before the error returned from `key.ECPrivKey()` is checked.

If that method returns an error, it will return nil and ethwallet will panic. However, this seems unlikely to ever happen in regular usage based on review of the ECPrivKey method at https://github.com/btcsuite/btcutil/blob/f648594deb8dacfc529b6c802f1d2c7018c20937/hdkeychain/extendedkey.go#L392.

I also added some test cases for how the wallet handles invalid mnemonics.

What do you think?