### PR TITLE
Fix "bounds out of range" error in AbiUnmarshalStringValues

### DIFF
--- a/ethcoder/abi.go
+++ b/ethcoder/abi.go
@@ -131,7 +131,7 @@ func AbiUnmarshalStringValues(argTypes []string, stringValues []string) ([]inter
 		switch typ {
 		case "address":
 			// expected "0xabcde......"
-			if s[0:2] != "0x" {
+			if !strings.HasPrefix(s, "0x") {
 				return nil, fmt.Errorf("ethcoder: value at position %d is invalid. expecting address in hex", i)
 			}
 			values = append(values, common.HexToAddress(s))
@@ -144,11 +144,12 @@ func AbiUnmarshalStringValues(argTypes []string, stringValues []string) ([]inter
 
 		case "bytes":
 			// expected: bytes in hex encoding with 0x prefix
-			if s[0:2] != "0x" {
+			if strings.HasPrefix(s, "0x") {
+				values = append(values, common.Hex2Bytes(s[2:]))
+				continue
+			} else {
 				return nil, fmt.Errorf("ethcoder: value at position %d is invalid. expecting bytes in hex", i)
 			}
-			values = append(values, common.Hex2Bytes(s[2:]))
-			continue
 
 		case "bool":
 			// expected: "true" | "false"
@@ -183,7 +184,7 @@ func AbiUnmarshalStringValues(argTypes []string, stringValues []string) ([]inter
 
 		// bytesXX (fixed)
 		if match := regexArgBytes.FindStringSubmatch(typ); len(match) > 0 {
-			if s[0:2] != "0x" {
+			if !strings.HasPrefix(s, "0x") {
 				return nil, fmt.Errorf("ethcoder: value at position %d is invalid. expecting bytes in hex", i)
 			}
 			size, err := strconv.ParseInt(match[1], 10, 64)

--- a/ethcoder/abi_test.go
+++ b/ethcoder/abi_test.go
@@ -249,6 +249,24 @@ func TestAbiUnmarshalStringValues(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, []uint8{170, 187, 204, 221, 170, 187, 204}, v2)
 	}
+
+	{
+		values, err := AbiUnmarshalStringValues([]string{"address", "uint256"}, []string{"", "2"})
+		assert.Error(t, err)
+		assert.Len(t, values, 0)
+	}
+
+	{
+		values, err := AbiUnmarshalStringValues([]string{"bytes", "uint256"}, []string{"0", "2"})
+		assert.Error(t, err)
+		assert.Len(t, values, 0)
+	}
+
+	{
+		values, err := AbiUnmarshalStringValues([]string{"bytes", "uint256"}, []string{"0z", "2"})
+		assert.Error(t, err)
+		assert.Len(t, values, 0)
+	}
 }
 
 // func TestAbiContractCall1(t *testing.T) {


### PR DESCRIPTION
This PR fixes a problem in `AbiUnmarshalStringValues`, the problem was that in some cases the passed slice does not have the expected format, or it is empty.

```
runtime error: slice bounds out of range [:2] with length 0
```