### PR TITLE
ethmonitor: fix goroutine leak

### DIFF
--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -510,6 +510,14 @@ func (m *Monitor) Subscribe() Subscription {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		close(subscriber.sendCh)
+
+		// flush subscriber.ch so that the makeUnboundedBuffered goroutine exits
+		for ok := true; ok; {
+			select {
+			case _, ok = <-subscriber.ch:
+			}
+		}
+
 		for i, sub := range m.subscribers {
 			if sub == subscriber {
 				m.subscribers = append(m.subscribers[:i], m.subscribers[i+1:]...)


### PR DESCRIPTION
The makeUnboundedBuffered goroutine only exits once the consumer has consumed all messages in the output channel. So we flush the buffered channel when unsubscribing from ethmonitor.