### PR TITLE
execute call if no args are passed

### DIFF
--- a/ethrpc/ethrpc.go
+++ b/ethrpc/ethrpc.go
@@ -132,6 +132,11 @@ func (s *Provider) queryContract(ctx context.Context, contractAddress string, in
 		if err != nil {
 			return nil, fmt.Errorf("abi encode failed: %w", err)
 		}
+	case nil:
+		calldata, err = ethcoder.AbiEncodeMethodCalldata(inputAbiExpr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("abi encode failed: %w", err)
+		}
 	}
 
 	msg := ethereum.CallMsg{


### PR DESCRIPTION
This was making queries like 
`provider.QueryContract(ctx, "0x000...", "contractURI()", "string", nil)`
fail where there was no argument