### PR TITLE
docs(readme): fixes, formatting and some polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ```
 =========================================================================================
-________________________________/\\\_____________________________________________________ 
-________________________________\/\\\___________/\\\_____________________________________ 
-______________________/\\\_______\/\\\__________\/\\\___________/\\\______/\\\___________ 
-________/\\\\\\\\___/\\\\\\\\\\\__\/\\\__________\/\\\___ /\\___\///____/\\\\\\\\\\\_____ 
-_______/\\\         \////\\\////___\/\\\\\\\\\\___\/\\\_ /\\\___________\////\\\////_____ 
-_______/\\\\\\\\\\\_____\/\\\_______\/\\\/////\\\__\/\\\\\\_______\/\\\_____\/\\\________ 
+________________________________/\\\_____________________________________________________
+________________________________\/\\\___________/\\\_____________________________________
+______________________/\\\_______\/\\\__________\/\\\___________/\\\______/\\\___________
+________/\\\\\\\\___/\\\\\\\\\\\__\/\\\__________\/\\\___ /\\___\///____/\\\\\\\\\\\_____
+_______/\\\         \////\\\////___\/\\\\\\\\\\___\/\\\_ /\\\___________\////\\\////_____
+_______/\\\\\\\\\\\_____\/\\\_______\/\\\/////\\\__\/\\\\\\_______\/\\\_____\/\\\________
 _______\//\\\            \/\\\_______\/\\\___\/\\\__\/\\\__\/\\\___\/\\\_____\/\\\_______
-________\//\\\\\\\\\\_____\//\\\\\____\/\\\___\/\\\__\/\\\__\/\\\___\/\\\_____\//\\\\\___ 
+________\//\\\\\\\\\\_____\//\\\\\____\/\\\___\/\\\__\/\\\__\/\\\___\/\\\_____\//\\\\\___
 _________\///////////______\//////_____\///____\///___\///___\///____\///______\/////____
 
 ==================================== we <3 Ethereum =====================================
@@ -16,30 +16,36 @@ _________\///////////______\//////_____\///____\///___\///___\///____\///______\
 Ethkit is an Ethereum [CLI](#ethkit-cli) and [Go development kit](#ethkit-go-development-library)
 designed to make it easier to use and develop for Ethereum.
 
-
-## Ethkit CLI
+# Ethkit CLI
 
 [![GoDoc Widget](https://godoc.org/github.com/0xsequence/ethkit?status.svg)](https://pkg.go.dev/github.com/0xsequence/ethkit) [![Go Report Card](https://goreportcard.com/badge/github.com/0xsequence/ethkit)](https://goreportcard.com/report/github.com/0xsequence/ethkit) ![example branch parameter](https://github.com/0xsequence/ethkit/actions/workflows/ci.yml/badge.svg?branch=master)
 
-Ethkit comes equipt with the `ethkit` CLI providing:
-  * Wallet -- manage Ethereum wallets & accounts. restore wallets from a secret mnemonic.
-    with scrypt wallet encryption support.
-  * Abigen -- generate Go code from an ABI artifact file to interact with or deploy a smart
-    contract.
-  * Artifacts -- parse details from a Truffle artifact file from command line such as contract
-    bytecode or the json abi
+Ethkit comes equipped with the `ethkit` CLI providing:
 
+- **Wallet** - manage Ethereum wallets & accounts. restore wallets from a secret mnemonic.
+  with scrypt wallet encryption support.
+- **Abigen** - generate Go code from an ABI artifact file to interact with or deploy a smart
+  contract.
+- **Artifacts** - parse details from a Truffle artifact file from command line such as contract
+  bytecode or the json abi
 
-#### Install
+## Install
 
-```go install github.com/0xsequence/ethkit/cmd/ethkit@latest```
+`go install github.com/0xsequence/ethkit/cmd/ethkit@latest`
 
-#### wallet
-```wallet``` handles encrypted Ethereum wallet creation and management in user-supplied keyfiles.
+## Run
+
+`ethkit [command]`
+
+## Commands
+
+### wallet
+
+`wallet` handles encrypted Ethereum wallet creation and management in user-supplied keyfiles.
 It allows users to create a new Ethereum wallet, import an existing Ethereum wallet from a secret
 mnemonic or print an existing wallet's secret mnemonic.
 
-```
+```bash
 Usage:
   ethkit wallet [flags]
 
@@ -52,12 +58,13 @@ Flags:
       --print-mnemonic    print wallet secret mnemonic from keyfile (danger!)
 ```
 
+### abigen
 
-#### abigen
-```abigen``` generates Go contract client code from a JSON [truffle](https://www.trufflesuite.com/)
+`abigen` generates Go contract client code from a JSON [truffle](https://www.trufflesuite.com/)
 artifacts file.
 
-```Usage:
+```bash
+Usage:
   ethkit abigen [flags]
 
 Flags:
@@ -70,10 +77,11 @@ Flags:
       --type string            type (optional)
 ```
 
-#### artifacts
-```artifacts``` prints the contract ABI or bytecode from a user-supplied truffle artifacts file.
+### artifacts
 
-```
+`artifacts` prints the contract ABI or bytecode from a user-supplied truffle artifacts file.
+
+```bash
 Usage:
   ethkit artifacts [flags]
 
@@ -84,7 +92,6 @@ Flags:
   -h, --help          help for artifacts
 ```
 
-
 ## Ethkit Go Development Library
 
 Ethkit is a very capable Ethereum development library for writing systems in Go that
@@ -94,21 +101,20 @@ we hope you enjoy it too.
 
 Packages:
 
-* `ethartifacts`: simple pkg to parse Truffle artifact file
-* `ethcoder`: encoding/decoding libraries for smart contracts and transactions
-* `ethdeploy`: simple method to deploy contract bytecode to a network
-* `ethgas`: fetch the latest gas price of a network or track over a period of time
-* `ethmonitor`: easily monitor block production, transactions and logs of a chain; with re-org support
-* `ethrpc`: http client for Ethereum json-rpc
-* `ethwallet`: wallet for Ethereum with support for wallet mnemonics (BIP-39)
-
+- `ethartifacts`: simple pkg to parse Truffle artifact file
+- `ethcoder`: encoding/decoding libraries for smart contracts and transactions
+- `ethdeploy`: simple method to deploy contract bytecode to a network
+- `ethgas`: fetch the latest gas price of a network or track over a period of time
+- `ethmonitor`: easily monitor block production, transactions and logs of a chain; with re-org support
+- `ethrpc`: http client for Ethereum json-rpc
+- `ethwallet`: wallet for Ethereum with support for wallet mnemonics (BIP-39)
 
 ## License
 
 Please see [LICENSE](./LICENSE) for full details.
 
-TLDR;
+TL;DR
 
-* All ethkit source is licensed under the MIT license, copyright (c) 2018-present [Horizon Blockchain Games Inc.](https://horizon.io)
-* All vendored+modified [go-ethereum](./go-ethereum) source is licensed under the original LGPLv3 license
-* All vendored source from go.mod dependencies is licensed under their respective licenses in [./vendor](./vendor) 
+- All ethkit source is licensed under the MIT license, copyright (c) 2018-present [Horizon Blockchain Games Inc.](https://horizon.io)
+- All vendored+modified [go-ethereum](./go-ethereum) source is licensed under the original LGPLv3 license
+- All vendored source from go.mod dependencies is licensed under their respective licenses in [./vendor](./vendor)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ designed to make it easier to use and develop for Ethereum.
 
 ## Ethkit CLI
 
+[![GoDoc Widget](https://godoc.org/github.com/0xsequence/ethkit?status.svg)](https://pkg.go.dev/github.com/0xsequence/ethkit) [![Go Report Card](https://goreportcard.com/badge/github.com/0xsequence/ethkit)](https://goreportcard.com/report/github.com/0xsequence/ethkit) ![example branch parameter](https://github.com/0xsequence/ethkit/actions/workflows/ci.yml/badge.svg?branch=master)
+
 Ethkit comes equipt with the `ethkit` CLI providing:
   * Wallet -- manage Ethereum wallets & accounts. restore wallets from a secret mnemonic.
     with scrypt wallet encryption support.
@@ -110,7 +112,3 @@ TLDR;
 * All ethkit source is licensed under the MIT license, copyright (c) 2018-present [Horizon Blockchain Games Inc.](https://horizon.io)
 * All vendored+modified [go-ethereum](./go-ethereum) source is licensed under the original LGPLv3 license
 * All vendored source from go.mod dependencies is licensed under their respective licenses in [./vendor](./vendor) 
-
-
-[GoDoc]: https://pkg.go.dev/github.com/0xsequence/ethkit
-[GoDoc Widget]: https://godoc.org/github.com/0xsequence/ethkit?status.svg

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ethkit comes equipt with the `ethkit` CLI providing:
 
 #### Install
 
-```go get github.com/0xsequence/ethkit/cmd/ethkit```
+```go install github.com/0xsequence/ethkit/cmd/ethkit@latest```
 
 #### wallet
 ```wallet``` handles encrypted Ethereum wallet creation and management in user-supplied keyfiles.


### PR DESCRIPTION
I started by fixing the install command and got carried away 😄 (but just minor fixes, nothing structural)

As it is mentioned [here](https://go.dev/doc/go-get-install-deprecation):
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

(Btw great work!)
