### PR TITLE
feat(cli): get balance for an account

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Ethkit comes equipped with the `ethkit` CLI providing:
   with scrypt wallet encryption support.
 - **Abigen** - generate Go code from an ABI artifact file to interact with or deploy a smart
   contract.
-- **Artifacts** - parse details from a Truffle artifact file from command line such as contract
-  bytecode or the json abi
+- **Artifacts** - parse details from a Truffle artifact file from the command line such as contract
+  bytecode or the JSON abi.
+- **Balance** - retrieve the balance of an account at any block height for any supported network via RPC.
 
 ## Install
 
@@ -42,8 +43,7 @@ Ethkit comes equipped with the `ethkit` CLI providing:
 ### wallet
 
 `wallet` handles encrypted Ethereum wallet creation and management in user-supplied keyfiles.
-It allows users to create a new Ethereum wallet, import an existing Ethereum wallet from a secret
-mnemonic or print an existing wallet's secret mnemonic.
+It allows users to create a new Ethereum wallet, import an existing Ethereum wallet from a secret mnemonic, or print an existing wallet's secret mnemonic.
 
 ```bash
 Usage:
@@ -90,6 +90,21 @@ Flags:
       --bytecode      bytecode
       --file string   path to truffle contract artifacts file (required)
   -h, --help          help for artifacts
+```
+
+### balance
+
+`balance` retrieves the balance of an account via RPC by a provided address at a predefined block height.
+
+```bash
+Usage:
+  ethkit balance [account] [flags]
+
+Flags:
+  -B, --block string     The block height to query at (default "latest")
+  -e, --ether            Format the balance in ether
+  -h, --help             help for balance
+  -r, --rpc-url string   The RPC endpoint to the blockchain node to interact with
 ```
 
 ## Ethkit Go Development Library

--- a/cmd/ethkit/balance.go
+++ b/cmd/ethkit/balance.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/0xsequence/ethkit/ethrpc"
+	"github.com/0xsequence/ethkit/go-ethereum/common"
+	"github.com/0xsequence/ethkit/go-ethereum/params"
+)
+
+func init() {
+	balance := &balance{}
+	cmd := &cobra.Command{
+		Use:   "balance [account]",
+		Short: "Get the balance of an account",
+		Args:  cobra.ExactArgs(1),
+		RunE:  balance.Run,
+	}
+
+	cmd.Flags().StringP("block", "B", "latest", "The block height to query at")
+	cmd.Flags().BoolP("ether", "e", false, "Format the balance in ether")
+	cmd.Flags().StringP("rpc-url", "r", "", "The RPC endpoint to the blockchain node to interact with")
+
+	rootCmd.AddCommand(cmd)
+}
+
+type balance struct {
+}
+
+func (c *balance) Run(cmd *cobra.Command, args []string) error {
+	fAccount := cmd.Flags().Args()[0]
+	fBlock, err := cmd.Flags().GetString("block")
+	if err != nil {
+		return err
+	}
+	fEther, err := cmd.Flags().GetBool("ether")
+	if err != nil {
+		return err
+	}
+	fRpc, err := cmd.Flags().GetString("rpc-url")
+	if err != nil {
+		return err
+	}
+
+	if !common.IsHexAddress(fAccount) {
+		return errors.New("error: please provide a valid account address (e.g. 0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742)")
+	}
+
+	if _, err = url.ParseRequestURI(fRpc); err != nil {
+		return errors.New("error: please provide a valid rpc url (e.g. https://nodes.sequence.app/mainnet)")
+	}
+
+	provider, err := ethrpc.NewProvider(fRpc)
+	if err != nil {
+		return err
+	}
+
+	block, err := strconv.ParseUint(fBlock, 10, 64)
+	if err != nil {
+		// TODO: implement support for all tags: earliest, latest, pending, finalized, safe
+		if fBlock == "latest" {
+			bh, err := provider.BlockNumber(context.Background())
+			if err != nil {
+				return err
+			}
+			block = bh
+		} else {
+			return errors.New("error: invalid block height")
+		}
+	}
+
+	wei, err := provider.BalanceAt(context.Background(), common.HexToAddress(fAccount), big.NewInt(int64(block)))
+	if err != nil {
+		return err
+	}
+
+	if fEther {
+		bal := weiToEther(wei)
+		fmt.Println(bal, "ether")
+	} else {
+		fmt.Println(wei, "wei")
+	}
+
+	return nil
+}
+
+// https://github.com/ethereum/go-ethereum/issues/21221
+func weiToEther(wei *big.Int) *big.Float {
+	f := new(big.Float)
+	f.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
+	f.SetMode(big.ToNearestEven)
+	fWei := new(big.Float)
+	fWei.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
+	fWei.SetMode(big.ToNearestEven)
+
+	return f.Quo(fWei.SetInt(wei), big.NewFloat(params.Ether))
+}

--- a/cmd/ethkit/balance.go
+++ b/cmd/ethkit/balance.go
@@ -16,19 +16,24 @@ import (
 )
 
 func init() {
-	balance := &balance{}
+	rootCmd.AddCommand(NewBalanceCmd())
+}
+
+func NewBalanceCmd() *cobra.Command {
+	c := &balance{}
 	cmd := &cobra.Command{
 		Use:   "balance [account]",
 		Short: "Get the balance of an account",
+		Aliases: []string{"b"},
 		Args:  cobra.ExactArgs(1),
-		RunE:  balance.Run,
+		RunE:  c.Run,
 	}
 
 	cmd.Flags().StringP("block", "B", "latest", "The block height to query at")
 	cmd.Flags().BoolP("ether", "e", false, "Format the balance in ether")
 	cmd.Flags().StringP("rpc-url", "r", "", "The RPC endpoint to the blockchain node to interact with")
 
-	rootCmd.AddCommand(cmd)
+	return cmd
 }
 
 type balance struct {

--- a/cmd/ethkit/balance.go
+++ b/cmd/ethkit/balance.go
@@ -15,6 +15,12 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/params"
 )
 
+const (
+	flagBalanceBlock = "block"
+	flagBalanceEther = "ether"
+	flagBalanceRpcUrl = "rpc-url"
+)
+
 func init() {
 	rootCmd.AddCommand(NewBalanceCmd())
 }
@@ -29,9 +35,9 @@ func NewBalanceCmd() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().StringP("block", "B", "latest", "The block height to query at")
-	cmd.Flags().BoolP("ether", "e", false, "Format the balance in ether")
-	cmd.Flags().StringP("rpc-url", "r", "", "The RPC endpoint to the blockchain node to interact with")
+	cmd.Flags().StringP(flagBalanceBlock, "B", "latest", "The block height to query at")
+	cmd.Flags().BoolP(flagBalanceEther, "e", false, "Format the balance in ether")
+	cmd.Flags().StringP(flagBalanceRpcUrl, "r", "", "The RPC endpoint to the blockchain node to interact with")
 
 	return cmd
 }
@@ -41,15 +47,15 @@ type balance struct {
 
 func (c *balance) Run(cmd *cobra.Command, args []string) error {
 	fAccount := cmd.Flags().Args()[0]
-	fBlock, err := cmd.Flags().GetString("block")
+	fBlock, err := cmd.Flags().GetString(flagBalanceBlock)
 	if err != nil {
 		return err
 	}
-	fEther, err := cmd.Flags().GetBool("ether")
+	fEther, err := cmd.Flags().GetBool(flagBalanceEther)
 	if err != nil {
 		return err
 	}
-	fRpc, err := cmd.Flags().GetString("rpc-url")
+	fRpc, err := cmd.Flags().GetString(flagBalanceRpcUrl)
 	if err != nil {
 		return err
 	}
@@ -88,9 +94,9 @@ func (c *balance) Run(cmd *cobra.Command, args []string) error {
 
 	if fEther {
 		bal := weiToEther(wei)
-		fmt.Println(bal, "ether")
+		fmt.Fprintln(cmd.OutOrStdout(), bal, "ether")
 	} else {
-		fmt.Println(wei, "wei")
+		fmt.Fprintln(cmd.OutOrStdout(), wei, "wei")
 	}
 
 	return nil

--- a/cmd/ethkit/balance_test.go
+++ b/cmd/ethkit/balance_test.go
@@ -9,29 +9,11 @@ import (
 	// "strconv"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
-func NewBalanceCommand() *cobra.Command {
-	balance := &balance{}
-
-	cmd := &cobra.Command{
-		Use:   "balance [account]",
-		Short: "Get the balance of an account",
-		Args:  cobra.ExactArgs(1),
-		RunE:  balance.Run,
-	}
-
-	cmd.Flags().StringP("block", "B","latest", "")
-	cmd.Flags().BoolP("ether", "e", false, "")
-	cmd.Flags().StringP("rpc-url", "r", "", "")
-
-	return cmd
-}
-
-func TestOKExecuteBalanceCommand(t *testing.T) {
-	cmd := NewBalanceCommand()
+func TestOKExecuteBalanceCmd(t *testing.T) {
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)
@@ -41,7 +23,7 @@ func TestOKExecuteBalanceCommand(t *testing.T) {
 
 // TODO: Fix bad output redirection that makes assert to fail
 func TestOKBalanceValidWei(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia"})
@@ -51,7 +33,7 @@ func TestOKBalanceValidWei(t *testing.T) {
 
 // TODO: Fix bad output redirection that makes assert to fail
 func TestOKBalanceValidEther(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)
@@ -61,7 +43,7 @@ func TestOKBalanceValidEther(t *testing.T) {
 }
 
 func TestFailInvalidAddress(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)
@@ -71,7 +53,7 @@ func TestFailInvalidAddress(t *testing.T) {
 }
 
 func TestFailInvalidRPC(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.Println(b)
 	cmd.SetErr(b)
@@ -81,7 +63,7 @@ func TestFailInvalidRPC(t *testing.T) {
 }
 
 func TestFailNotExistingBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)
@@ -91,7 +73,7 @@ func TestFailNotExistingBlockHeigh(t *testing.T) {
 }
 
 func TestFailNotAValidStringBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)
@@ -101,7 +83,7 @@ func TestFailNotAValidStringBlockHeigh(t *testing.T) {
 }
 
 func TestFailNotAValidNumberBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCommand()
+	cmd := NewBalanceCmd()
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 	cmd.SetErr(b)

--- a/cmd/ethkit/balance_test.go
+++ b/cmd/ethkit/balance_test.go
@@ -2,91 +2,76 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"strconv"
-
-	// "fmt"
-	// "strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOKExecuteBalanceCmd(t *testing.T) {
+func execute(args string) (string, error) {
 	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia"})
-	assert.NoError(t, cmd.Execute())
+	actual := new(bytes.Buffer)
+	cmd.SetOut(actual)
+	cmd.SetErr(actual)
+	cmd.SetArgs(strings.Split(args, " "))
+	if err := cmd.Execute(); err != nil {
+		return "", err
+	}
+
+	return actual.String(), nil
 }
 
-// TODO: Fix bad output redirection that makes assert to fail
-func TestOKBalanceValidWei(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia"})
-	assert.NoError(t, cmd.Execute())
-	// assert.Equal(t, b.String(), fmt.Sprintln(strconv.Itoa(500_000_000_000_000_000), "wei"))
+func Test_BalanceCmd(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia")
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
 }
 
-// TODO: Fix bad output redirection that makes assert to fail
-func TestOKBalanceValidEther(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--ether"})
-	assert.NoError(t, cmd.Execute())
-	// assert.Equal(t, b.String(), fmt.Sprintln(strconv.FormatFloat(0.5, 'f', -1, 64), "ether"))
+func Test_BalanceCmd_ValidWei(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia")
+	assert.Nil(t, err)
+	assert.Equal(t, res, fmt.Sprintln(strconv.Itoa(500_000_000_000_000_000), "wei"))
 }
 
-func TestFailInvalidAddress(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x1", "--rpc-url", "https://nodes.sequence.app/sepolia"})
-	assert.Error(t, cmd.Execute())
-	assert.Contains(t, b.String(), "valid account address")
+func Test_BalanceCmd_ValidEther(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --ether")
+	assert.Nil(t, err)
+	assert.Equal(t, res, fmt.Sprintln(strconv.FormatFloat(0.5, 'f', -1, 64), "ether"))
 }
 
-func TestFailInvalidRPC(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.Println(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "nodes.sequence.app/sepolia"})
-	assert.Error(t, cmd.Execute())
-	assert.Contains(t, b.String(), "valid rpc url")
+func Test_BalanceCmd_InvalidAddress(t *testing.T) {
+	res, err := execute("0x1 --rpc-url https://nodes.sequence.app/sepolia")
+	assert.NotNil(t, err)
+	assert.Empty(t, res)
+	assert.Contains(t, err.Error(), "please provide a valid account address")
 }
 
-func TestFailNotExistingBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", strconv.FormatInt(math.MaxInt64, 10)})
-	assert.Error(t, cmd.Execute())
-	assert.Contains(t, b.String(), "jsonrpc error -32000: header not found")
+func Test_BalanceCmd_InvalidRPC(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url nodes.sequence.app/sepolia")
+	assert.NotNil(t, err)
+	assert.Empty(t, res)
+	assert.Contains(t, err.Error(), "please provide a valid rpc url")
 }
 
-func TestFailNotAValidStringBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", "something"})
-	assert.Error(t, cmd.Execute())
-	assert.Contains(t, b.String(), "invalid block height")
+func Test_BalanceCmd_NotExistingBlockHeigh(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --block " + fmt.Sprint(math.MaxInt64))
+	assert.NotNil(t, err)
+	assert.Empty(t, res)
+	assert.Contains(t, err.Error(), "jsonrpc error -32000: header not found")
 }
 
-func TestFailNotAValidNumberBlockHeigh(t *testing.T) {
-	cmd := NewBalanceCmd()
-	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(b)
-	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", "-100"})
-	assert.Error(t, cmd.Execute())
+func Test_BalanceCmd_NotAValidStringBlockHeigh(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --block something")
+	assert.NotNil(t, err)
+	assert.Empty(t, res)
+	assert.Contains(t, err.Error(), "invalid block height")
+}
+
+func Test_BalanceCmd_NotAValidNumberBlockHeigh(t *testing.T) {
+	res, err := execute("0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --block -100")
+	assert.NotNil(t, err)
+	assert.Empty(t, res)
 }

--- a/cmd/ethkit/balance_test.go
+++ b/cmd/ethkit/balance_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"strconv"
+
+	// "fmt"
+	// "strconv"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewBalanceCommand() *cobra.Command {
+	balance := &balance{}
+
+	cmd := &cobra.Command{
+		Use:   "balance [account]",
+		Short: "Get the balance of an account",
+		Args:  cobra.ExactArgs(1),
+		RunE:  balance.Run,
+	}
+
+	cmd.Flags().StringP("block", "B","latest", "")
+	cmd.Flags().BoolP("ether", "e", false, "")
+	cmd.Flags().StringP("rpc-url", "r", "", "")
+
+	return cmd
+}
+
+func TestOKExecuteBalanceCommand(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia"})
+	assert.NoError(t, cmd.Execute())
+}
+
+// TODO: Fix bad output redirection that makes assert to fail
+func TestOKBalanceValidWei(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia"})
+	assert.NoError(t, cmd.Execute())
+	// assert.Equal(t, b.String(), fmt.Sprintln(strconv.Itoa(500_000_000_000_000_000), "wei"))
+}
+
+// TODO: Fix bad output redirection that makes assert to fail
+func TestOKBalanceValidEther(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--ether"})
+	assert.NoError(t, cmd.Execute())
+	// assert.Equal(t, b.String(), fmt.Sprintln(strconv.FormatFloat(0.5, 'f', -1, 64), "ether"))
+}
+
+func TestFailInvalidAddress(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x1", "--rpc-url", "https://nodes.sequence.app/sepolia"})
+	assert.Error(t, cmd.Execute())
+	assert.Contains(t, b.String(), "valid account address")
+}
+
+func TestFailInvalidRPC(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.Println(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "nodes.sequence.app/sepolia"})
+	assert.Error(t, cmd.Execute())
+	assert.Contains(t, b.String(), "valid rpc url")
+}
+
+func TestFailNotExistingBlockHeigh(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", strconv.FormatInt(math.MaxInt64, 10)})
+	assert.Error(t, cmd.Execute())
+	assert.Contains(t, b.String(), "jsonrpc error -32000: header not found")
+}
+
+func TestFailNotAValidStringBlockHeigh(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", "something"})
+	assert.Error(t, cmd.Execute())
+	assert.Contains(t, b.String(), "invalid block height")
+}
+
+func TestFailNotAValidNumberBlockHeigh(t *testing.T) {
+	cmd := NewBalanceCommand()
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{"0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742", "--rpc-url", "https://nodes.sequence.app/sepolia", "--block", "-100"})
+	assert.Error(t, cmd.Execute())
+}


### PR DESCRIPTION
# Description

Initial implementation of the [`eth_getBalance`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getbalance) JSON-RPC call for ethkit CLI.

# Examples

- Retrieve the account balance (**in wei**) for address `0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742` on Sepolia network via `https://nodes.sequence.app/sepolia` RPC endpoint at `latest` block

```bash
ethkit balance 0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia
```

- Retrieve the account balance (**in ether**) for address `0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742` on Sepolia network via `https://nodes.sequence.app/sepolia` RPC endpoint  at `latest` block

```bash
ethkit balance 0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --ether
```

- Retrieve the `latest` account balance (**in ether**) for address `0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742` on Sepolia network via `https://nodes.sequence.app/sepolia` RPC endpoint  at block `4861405`

```bash
ethkit balance 0x213a286A1AF3Ac010d4F2D66A52DeAf762dF7742 --rpc-url https://nodes.sequence.app/sepolia --ether --block 4861405
```