### PR TITLE
feat(cli): get block by number

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ethkit comes equipped with the `ethkit` CLI providing:
   contract.
 - **Artifacts** - parse details from a Truffle artifact file from command line such as contract
   bytecode or the json abi
+- **Block** - retrieve the block information based on block height (or tag) and filtered by optional input parameters
 
 ## Install
 
@@ -90,6 +91,25 @@ Flags:
       --bytecode      bytecode
       --file string   path to truffle contract artifacts file (required)
   -h, --help          help for artifacts
+```
+
+### block
+
+`block` retrieves a block by a provided block height or tag via RPC
+
+```bash
+Usage:
+  ethkit block [number|tag] [flags]
+
+Aliases:
+  block, bl
+
+Flags:
+  -f, --field string     Get the specific field of a block
+      --full             Get the full block information
+  -h, --help             help for block
+  -j, --json             Print the block as JSON
+  -r, --rpc-url string   The RPC endpoint to the blockchain node to interact with
 ```
 
 ## Ethkit Go Development Library

--- a/cmd/ethkit/block.go
+++ b/cmd/ethkit/block.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/0xsequence/ethkit/ethrpc"
+	"github.com/0xsequence/ethkit/go-ethereum/common"
+	"github.com/0xsequence/ethkit/go-ethereum/core/types"
+)
+
+const (
+	flagBlockField = "field"
+	flagBlockFull = "full"
+	flagBlockRpcUrl = "rpc-url"
+	flagBlockJson = "json"
+)
+
+func init() {
+	rootCmd.AddCommand(NewBlockCmd())
+}
+
+type block struct {
+}
+
+// NewBlockCommand returns a new build command to retrieve a block.
+func NewBlockCmd() *cobra.Command {
+	c := &block{}
+	cmd := &cobra.Command{
+		Use:     "block [number|tag]",
+		Short:   "Get the information about the block",
+		Aliases: []string{"bl"},
+		Args:    cobra.ExactArgs(1),
+		RunE:    c.Run,
+	}
+
+	cmd.Flags().StringP(flagBlockField, "f", "", "Get the specific field of a block")
+	cmd.Flags().Bool(flagBlockFull, false, "Get the full block information")
+	cmd.Flags().StringP(flagBlockRpcUrl, "r", "", "The RPC endpoint to the blockchain node to interact with")
+	cmd.Flags().BoolP(flagBlockJson, "j", false, "Print the block as JSON")
+
+	return cmd
+}
+
+func (c *block) Run(cmd *cobra.Command, args []string) error {
+	fBlock := cmd.Flags().Args()[0]
+	fField, err := cmd.Flags().GetString(flagBlockField)
+	if err != nil {
+		return err
+	}
+	fFull, err := cmd.Flags().GetBool(flagBlockFull)
+	if err != nil {
+		return err
+	}
+	fRpc, err := cmd.Flags().GetString(flagBlockRpcUrl)
+	if err != nil {
+		return err
+	}
+	fJson, err := cmd.Flags().GetBool(flagBlockJson)
+	if err != nil {
+		return err
+	}
+
+	if _, err = url.ParseRequestURI(fRpc); err != nil {
+		return errors.New("error: please provide a valid rpc url (e.g. https://nodes.sequence.app/mainnet)")
+	}
+
+	provider, err := ethrpc.NewProvider(fRpc)
+	if err != nil {
+		return err
+	}
+
+	bh, err := strconv.ParseUint(fBlock, 10, 64)
+	if err != nil {
+		// TODO: implement support for all tags: earliest, latest, pending, finalized, safe
+		return errors.New("error: invalid block height")
+	}
+
+	block, err := provider.BlockByNumber(context.Background(), big.NewInt(int64(bh)))
+	if err != nil {
+		return err
+	}
+
+	var obj any
+	obj = NewHeader(block)
+
+	if fFull {
+		obj = NewBlock(block)
+	}
+
+	if fField != "" {
+		obj = GetValueByJSONTag(obj, fField)
+	}
+
+	if fJson {
+		json, err := PrettyJSON(obj)
+		if err != nil {
+			return err
+		}
+		obj = *json
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), obj)
+
+	return nil
+}
+
+// Header is a customized block header for cli.
+type Header struct {
+	ParentHash       common.Hash        `json:"parentHash"`
+	UncleHash        common.Hash        `json:"sha3Uncles"`
+	Coinbase         common.Address     `json:"miner"`
+	Hash             common.Hash        `json:"hash"`
+	Root             common.Hash        `json:"stateRoot"`
+	TxHash           common.Hash        `json:"transactionsRoot"`
+	ReceiptHash      common.Hash        `json:"receiptsRoot"`
+	Bloom            types.Bloom        `json:"logsBloom"`
+	Difficulty       *big.Int           `json:"difficulty"`
+	Number           *big.Int           `json:"number"`
+	GasLimit         uint64             `json:"gasLimit"`
+	GasUsed          uint64             `json:"gasUsed"`
+	Time             uint64             `json:"timestamp"`
+	Extra            []byte             `json:"extraData"`
+	MixDigest        common.Hash        `json:"mixHash"`
+	Nonce            types.BlockNonce   `json:"nonce"`
+	BaseFee          *big.Int           `json:"baseFeePerGas"`
+	WithdrawalsHash  *common.Hash       `json:"withdrawalsRoot"`
+	Size             common.StorageSize `json:"size"`
+	// TODO: totalDifficulty to be implemented
+	// TotalDifficulty  *big.Int           `json:"totalDifficulty"`
+	TransactionsHash []common.Hash      `json:"transactions"`
+}
+
+// NewHeader returns the custom-built Header object.
+func NewHeader(b *types.Block) *Header {
+	return &Header{
+		ParentHash:       b.Header().ParentHash,
+		UncleHash:        b.Header().UncleHash,
+		Coinbase:         b.Header().Coinbase,
+		Hash:             b.Hash(),
+		Root:             b.Header().Root,
+		TxHash:           b.Header().TxHash,
+		ReceiptHash:      b.ReceiptHash(),
+		Bloom:            b.Bloom(),
+		Difficulty:       b.Header().Difficulty,
+		Number:           b.Header().Number,
+		GasLimit:         b.Header().GasLimit,
+		GasUsed:          b.Header().GasUsed,
+		Time:             b.Header().Time,
+		Extra:            b.Header().Extra,
+		MixDigest:        b.Header().MixDigest,
+		Nonce:            b.Header().Nonce,
+		BaseFee:          b.Header().BaseFee,
+		WithdrawalsHash:  b.Header().WithdrawalsHash,
+		Size:             b.Size(),
+		// TotalDifficulty:  b.Difficulty(),
+		TransactionsHash: TransactionsHash(*b),
+	}
+}
+
+// String overrides the standard behavior for Header "to-string".
+func (h *Header) String() string {
+	var p Printable
+	if err := p.FromStruct(h); err != nil {
+		panic(err)
+	}
+	s := p.Columnize(*NewPrintableFormat(20, 0, 0, byte(' ')))
+
+	return s
+}
+
+// TransactionsHash returns a list of transaction hash starting from a list of transactions contained in a block.
+func TransactionsHash(block types.Block) []common.Hash {
+	txsh := make([]common.Hash, len(block.Transactions()))
+
+	for i, tx := range block.Transactions() {
+		txsh[i] = tx.Hash()
+	}
+
+	return txsh
+}
+
+// Block is a customized block for cli.
+type Block struct {
+	ParentHash      common.Hash        `json:"parentHash"`
+	UncleHash       common.Hash        `json:"sha3Uncles"`
+	Coinbase        common.Address     `json:"miner"`
+	Hash            common.Hash        `json:"hash"`
+	Root            common.Hash        `json:"stateRoot"`
+	TxHash          common.Hash        `json:"transactionsRoot"`
+	ReceiptHash     common.Hash        `json:"receiptsRoot"`
+	Bloom           types.Bloom        `json:"logsBloom"`
+	Difficulty      *big.Int           `json:"difficulty"`
+	Number          *big.Int           `json:"number"`
+	GasLimit        uint64             `json:"gasLimit"`
+	GasUsed         uint64             `json:"gasUsed"`
+	Time            uint64             `json:"timestamp"`
+	Extra           []byte             `json:"extraData"`
+	MixDigest       common.Hash        `json:"mixHash"`
+	Nonce           types.BlockNonce   `json:"nonce"`
+	BaseFee         *big.Int           `json:"baseFeePerGas"`
+	WithdrawalsHash *common.Hash       `json:"withdrawalsRoot"`
+	Size            common.StorageSize `json:"size"`
+	// TODO: totalDifficulty to be implemented
+	// TotalDifficulty *big.Int           `json:"totalDifficulty"`
+	Uncles          []*types.Header    `json:"uncles"`
+	Transactions    types.Transactions `json:"transactions"`
+	Withdrawals     types.Withdrawals  `json:"withdrawals"`
+}
+
+// NewBlock returns the custom-built Block object.
+func NewBlock(b *types.Block) *Block {
+	return &Block{
+		ParentHash:      b.Header().ParentHash,
+		UncleHash:       b.Header().UncleHash,
+		Coinbase:        b.Header().Coinbase,
+		Hash:            b.Hash(),
+		Root:            b.Header().Root,
+		TxHash:          b.Header().TxHash,
+		ReceiptHash:     b.ReceiptHash(),
+		Bloom:           b.Bloom(),
+		Difficulty:      b.Header().Difficulty,
+		Number:          b.Header().Number,
+		GasLimit:        b.Header().GasLimit,
+		GasUsed:         b.Header().GasUsed,
+		Time:            b.Header().Time,
+		Extra:           b.Header().Extra,
+		MixDigest:       b.Header().MixDigest,
+		Nonce:           b.Header().Nonce,
+		BaseFee:         b.Header().BaseFee,
+		WithdrawalsHash: b.Header().WithdrawalsHash,
+		Size:            b.Size(),
+		// TotalDifficulty: b.Difficulty(),
+		Uncles:          b.Uncles(),
+		Transactions:    b.Transactions(),
+		// TODO: Withdrawals is empty. To be fixed.
+		Withdrawals:     b.Withdrawals(),
+	}
+}
+
+// String overrides the standard behavior for Block "to-string".
+func (b *Block) String() string {
+	var p Printable
+	if err := p.FromStruct(b); err != nil {
+		panic(err)
+	}
+	s := p.Columnize(*NewPrintableFormat(20, 0, 0, byte(' ')))
+
+	return s
+}

--- a/cmd/ethkit/block_test.go
+++ b/cmd/ethkit/block_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/0xsequence/ethkit/go-ethereum/common/math"
+	"github.com/stretchr/testify/assert"
+)
+
+func execute(args string) (string, error) {
+	cmd := NewBlockCmd()
+	actual := new(bytes.Buffer)
+	cmd.SetOut(actual)
+	cmd.SetErr(actual)
+	cmd.SetArgs(strings.Split(args, " "))
+	if err := cmd.Execute(); err != nil {
+		return "", err
+	}
+
+	return actual.String(), nil
+}
+
+func Test_BlockCmd(t *testing.T) {
+	res, err := execute("18855325 --rpc-url https://nodes.sequence.app/mainnet")
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+}
+
+func Test_BlockCmd_InvalidRpcUrl(t *testing.T) {
+	res, err := execute("18855325 --rpc-url nodes.sequence.app/mainnet")
+	assert.Contains(t, err.Error(), "please provide a valid rpc url")
+	assert.Empty(t, res)
+}
+
+// Note: this test will eventually fail
+func Test_BlockCmd_NotFound(t *testing.T) {
+	res, err := execute(fmt.Sprint(math.MaxInt64) + " --rpc-url https://nodes.sequence.app/mainnet")
+	assert.Contains(t, err.Error(), "not found")
+	assert.Empty(t, res)
+}
+
+func Test_BlockCmd_InvalidBlockHeight(t *testing.T) {
+	res, err := execute("invalid --rpc-url https://nodes.sequence.app/mainnet")
+	assert.Contains(t, err.Error(), "invalid block height")
+	assert.Empty(t, res)
+}
+
+func Test_BlockCmd_HeaderValidJSON(t *testing.T) {
+	res, err := execute("18855325 --rpc-url https://nodes.sequence.app/mainnet --json")
+	assert.Nil(t, err)
+	h := Header{}
+	var p Printable
+	_ = p.FromStruct(h)
+	for k := range p {
+		assert.Contains(t, res, k)
+	}
+}
+
+func Test_BlockCmd_BlockValidJSON(t *testing.T) {
+	res, err := execute("18855325 --rpc-url https://nodes.sequence.app/mainnet --full --json")
+	assert.Nil(t, err)
+	h := Block{}
+	var p Printable
+	_ = p.FromStruct(h)
+	for k := range p {
+		assert.Contains(t, res, k)
+	}
+}
+
+func Test_BlockCmd_BlockValidFieldHash(t *testing.T) {
+	// validating also that -f is case-insensitive
+	res, err := execute("18855325 --rpc-url https://nodes.sequence.app/mainnet --full -f HASh")
+	assert.Nil(t, err)
+	assert.Equal(t, res, "0x97e5c24dc2fd74f6e56773a0ad1cf29fe403130ca6ec1dd10ff8828d72b0a352\n")
+}
+
+func Test_BlockCmd_BlockInvalidField(t *testing.T) {
+	res, err := execute("18855325 --rpc-url https://nodes.sequence.app/mainnet --full -f invalid")
+	assert.Nil(t, err)
+	assert.Equal(t, res, "<nil>\n")
+}

--- a/cmd/ethkit/print.go
+++ b/cmd/ethkit/print.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+)
+
+type printableFormat struct {
+	minwidth int
+	tabwidth int
+	padding  int
+	padchar  byte
+}
+
+// NewPrintableFormat returns a customized configuration format
+func NewPrintableFormat(minwidth, tabwidth, padding int, padchar byte) *printableFormat {
+	return &printableFormat{minwidth, tabwidth, padding, padchar}
+}
+
+// Printable is a generic key-value (map) structure that could contain nested objects.
+type Printable map[string]any
+
+// PrettyJSON prints an object in "prettified" JSON format
+func PrettyJSON(toJSON any) (*string, error) {
+	b, err := json.MarshalIndent(toJSON, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	jsonString := string(b)
+
+	// remove the trailing newline character ("%")
+	if jsonString[len(jsonString)-1] == '\n' {
+		jsonString = jsonString[:len(jsonString)-1]
+	}
+
+	return &jsonString, nil
+}
+
+// FromStruct converts a struct into a Printable using, when available, JSON field names as keys
+func (p *Printable) FromStruct(input any) error {
+	bytes, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(bytes, &p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Columnize returns a formatted-in-columns (vertically aligned) string based on a provided configuration.
+func (p *Printable) Columnize(pf printableFormat) string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, pf.minwidth, pf.tabwidth, pf.padding, pf.padchar, tabwriter.Debug)
+	// NOTE: Order is not maintained whilst looping over map's . Results from different execution may differ.
+	for k, v := range *p {
+		printKeyValue(w, k, v)
+	}
+	w.Flush()
+
+	return buf.String()
+}
+
+func printKeyValue(w *tabwriter.Writer, key string, value any) {
+	switch t := value.(type) {
+	// NOTE: Printable is not directly inferred as map[string]any therefore explicit reference is necessary
+	case map[string]any:
+		fmt.Fprintln(w, key, "\t")
+		for tk, tv := range t {
+			printKeyValue(w, "\t"+tk, tv)
+		}
+	case []any:
+		fmt.Fprintln(w, key, "\t")
+		for _, elem := range t {
+			elemMap, ok := elem.(map[string]any)
+			if ok {
+				for tk, tv := range elemMap {
+					printKeyValue(w, "\t"+tk, tv)
+				}
+				fmt.Fprintln(w, "\t", "\t")
+			} else {
+				fmt.Fprintln(w, "\t", elem)
+			}
+		}
+	default:
+		// custom format for numbers to avoid scientific notation
+		fmt.Fprintf(w, "%s\t %s\n", key, customFormat(value))
+	}
+}
+
+func customFormat(value any) string {
+	switch v := value.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v)
+	case float32, float64:
+		return formatFloat(v)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func formatFloat(f any) string {
+	str := fmt.Sprintf("%v", f)
+	if strings.ContainsAny(str, "eE.") {
+		if floatValue, err := strconv.ParseFloat(str, 64); err == nil {
+			return strconv.FormatFloat(floatValue, 'f', -1, 64)
+		}
+	}
+
+	return str
+}
+
+// GetValueByJSONTag returns the value of a struct field matching a JSON tag provided in input.
+func GetValueByJSONTag(input any, jsonTag string) any {
+	return findField(reflect.ValueOf(input), jsonTag)
+}
+
+func findField(val reflect.Value, jsonTag string) any {
+	seen := make(map[uintptr]bool)
+
+	// take the value the pointer val points to
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	// return if the element is not a struct
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
+
+	// check if the struct has already been processed to avoid infinite recursion
+	if val.CanAddr() {
+		ptr := val.Addr().Pointer()
+		if seen[ptr] {
+			return nil
+		}
+		seen[ptr] = true
+	}
+
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		tag := field.Tag.Get("json")
+
+		fieldValue := val.Field(i)
+		if fieldValue.Kind() == reflect.Struct {
+			// recursively process fields including embedded ones
+			return findField(fieldValue, jsonTag)
+		} else {
+			if strings.EqualFold(strings.ToLower(tag), strings.ToLower(jsonTag)) {
+				return val.Field(i).Interface()
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/ethkit/print.go
+++ b/cmd/ethkit/print.go
@@ -73,7 +73,7 @@ func printKeyValue(w *tabwriter.Writer, key string, value any) {
 	case map[string]any:
 		fmt.Fprintln(w, key, "\t")
 		for tk, tv := range t {
-			printKeyValue(w, "\t"+tk, tv)
+			printKeyValue(w, "\t "+tk, tv)
 		}
 	case []any:
 		fmt.Fprintln(w, key, "\t")
@@ -81,7 +81,7 @@ func printKeyValue(w *tabwriter.Writer, key string, value any) {
 			elemMap, ok := elem.(map[string]any)
 			if ok {
 				for tk, tv := range elemMap {
-					printKeyValue(w, "\t"+tk, tv)
+					printKeyValue(w, "\t "+tk, tv)
 				}
 				fmt.Fprintln(w, "\t", "\t")
 			} else {
@@ -143,10 +143,10 @@ func findField(val reflect.Value, jsonTag string) any {
 		seen[ptr] = true
 	}
 
-	typ := val.Type()
+	t := val.Type()
 
 	for i := 0; i < val.NumField(); i++ {
-		field := typ.Field(i)
+		field := t.Field(i)
 		tag := field.Tag.Get("json")
 
 		fieldValue := val.Field(i)

--- a/cmd/ethkit/print_test.go
+++ b/cmd/ethkit/print_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	complex = struct {
+		Name    string           `json:"name"`
+		List    []any            `json:"list"`
+		Nested  Nested           `json:"nested"`
+		Object  map[string]any   `json:"object"`
+		ObjList []map[string]any `json:"objList"`
+	}{
+		Name: "complex",
+		List: []any{
+			"first",
+			"second",
+		},
+		Nested: Nested{
+			Title: "hello",
+			Value: 500000000,
+		},
+		Object: map[string]any{
+			"obj1": 1,
+			"obj2": -2,
+		},
+		ObjList: []map[string]any{
+			{
+				"item1": 1,
+				"item2": 2,
+			},
+			{
+				"item3": 3e7,
+				"item4": 2e7,
+				"item5": 2.123456e7,
+			},
+		},
+	}
+
+	s        string
+	rows     []string
+	p        Printable
+	minwidth = 20
+	tabwidth = 0
+	padding  = 0
+	padchar  = byte(' ')
+)
+
+type Nested struct {
+	Title string `json:"title"`
+	Value uint   `json:"value"`
+}
+
+func setup() {
+	if err := p.FromStruct(complex); err != nil {
+		panic(err)
+	}
+	s = p.Columnize(*NewPrintableFormat(minwidth, tabwidth, padding, padchar))
+	rows = strings.Split(s, "\n")
+}
+
+func Test_Columnize(t *testing.T) {
+	setup()
+	for i := 0; i < len(rows); i++ {
+		if rows[i] != "" {
+			// the delimiter should be in the same position in all the rows
+			assert.Equal(t, strings.Index(rows[i], "|"), minwidth)
+		}
+	}
+}
+
+func Test_GetValueByJSONTag(t *testing.T) {
+	setup()
+	tag := "title"
+	assert.Equal(t, GetValueByJSONTag(complex, tag), complex.Nested.Title)
+}
+
+func Test_GetValueByJSONTag_FailWhenNotStruct(t *testing.T) {
+	setup()
+	tag := "title"
+	assert.Nil(t, GetValueByJSONTag(p, tag))
+}

--- a/cmd/ethkit/print_test.go
+++ b/cmd/ethkit/print_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -35,7 +37,7 @@ var (
 			},
 			{
 				"item3": 3e7,
-				"item4": 2e7,
+				"item4": 2E7,
 				"item5": 2.123456e7,
 			},
 		},
@@ -44,7 +46,7 @@ var (
 	s        string
 	rows     []string
 	p        Printable
-	minwidth = 20
+	minwidth = 24
 	tabwidth = 0
 	padding  = 0
 	padchar  = byte(' ')
@@ -60,6 +62,7 @@ func setup() {
 		panic(err)
 	}
 	s = p.Columnize(*NewPrintableFormat(minwidth, tabwidth, padding, padchar))
+	fmt.Println(s)
 	rows = strings.Split(s, "\n")
 }
 
@@ -69,6 +72,12 @@ func Test_Columnize(t *testing.T) {
 		if rows[i] != "" {
 			// the delimiter should be in the same position in all the rows
 			assert.Equal(t, strings.Index(rows[i], "|"), minwidth)
+			if strings.Contains(rows[i], "item5") {
+				v := strconv.FormatFloat(complex.ObjList[1]["item5"].(float64), 'f', -1, 64)
+				// the value of the nested object should be indented to the 3rd column and it should be parsed as an integer
+				// left bound: 2*\t + 1*' ' = 3 , right bound: 3 + len(21234560) + 1 = 11
+				assert.Equal(t, rows[i][minwidth*2+3:minwidth*2+11], v)
+			}
 		}
 	}
 }

--- a/ethrpc/block.go
+++ b/ethrpc/block.go
@@ -25,9 +25,10 @@ type txExtraInfo struct {
 }
 
 type rpcBlock struct {
-	Hash         common.Hash      `json:"hash"`
-	Transactions []rpcTransaction `json:"transactions"`
-	UncleHashes  []common.Hash    `json:"uncles"`
+	Hash         common.Hash       `json:"hash"`
+	Transactions []rpcTransaction  `json:"transactions"`
+	UncleHashes  []common.Hash     `json:"uncles"`
+	Withdrawals  types.Withdrawals `json:"withdrawals"`
 }
 
 func (tx *rpcTransaction) UnmarshalJSON(msg []byte) error {
@@ -50,7 +51,7 @@ func IntoBlock(raw json.RawMessage, ret **types.Block) error {
 	if len(raw) == 0 {
 		return ethereum.NotFound
 	}
-
+	
 	// Decode header and transactions
 	var (
 		head *types.Header
@@ -88,7 +89,7 @@ func IntoBlock(raw json.RawMessage, ret **types.Block) error {
 	}
 
 	// return types.NewBlockWithHeader(head).WithBody(txs, uncles), nil
-	block := types.NewBlockWithHeader(head).WithBody(txs, nil)
+	block := types.NewBlockWithHeader(head).WithBody(txs, nil).WithWithdrawals(body.Withdrawals)
 
 	// TODO: Remove this, we shouldn't need to use the block cache
 	// in order for it to contain the correct block hash

--- a/go-ethereum/core/types/withdrawal.go
+++ b/go-ethereum/core/types/withdrawal.go
@@ -29,10 +29,10 @@ import (
 
 // Withdrawal represents a validator withdrawal from the consensus layer.
 type Withdrawal struct {
-	Index     uint64         `json:"index"`          // monotonically increasing identifier issued by consensus layer
-	Validator uint64         `json:"validatorIndex"` // index of validator associated with withdrawal
+	Index     hexutil.Uint64 `json:"index"`          // monotonically increasing identifier issued by consensus layer
+	Validator hexutil.Uint64 `json:"validatorIndex"` // index of validator associated with withdrawal
 	Address   common.Address `json:"address"`        // target address for withdrawn ether
-	Amount    uint64         `json:"amount"`         // value of withdrawal in Gwei
+	Amount    hexutil.Uint64 `json:"amount"`         // value of withdrawal in Gwei
 }
 
 // field type overrides for gencodec


### PR DESCRIPTION
# Description

Initial implementation of the [eth_getBlockByNumber](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber) JSON-RPC call for ethkit CLI.

Depends on #111

## Key features

- Support for block header
- Support for full block
- Support for JSON formatted result
- Support for single-field results (case-insensitive)

## TODOs & known issues

- The `totalDifficulty` field has to be implemented
- ~Currently, the `withdrawals` field returns an empty list when a non-empty result is expected~ - fixed in 4663b82f69021493a1bdf495dd180c2d60032947
- Tags - `earliest`, `latest`, `pending`, `finalized`, `safe` - are currently not supported
- ~`extraData` is printed as a string encoded in base64 (expected: hex-encoded)~ - fixed in e3cf35303c061bde80f0a2fb40fd9faea892a715
- The order of printed fields is not maintained at each iteration. This is a known behaviour for looping through map structures. If ordering is required (for deterministic results), this can be easily fixed

# Examples

Retrieve the block header for block `18855325` on mainnet network via `https://nodes.sequence.app/mainnet` RPC endpoint and print the result in console formatted in columns with the same width:

```shell
ethkit block 18855325 -r https://nodes.sequence.app/mainnet
```

Retrieve the `timestamp` for block `18855325` on mainnet network via `https://nodes.sequence.app/mainnet` RPC endpoint and print the result in console as a single-value field:

```shell
ethkit block 18855325 -r https://nodes.sequence.app/mainnet -f timestamp
```

Retrieve the full block information for block `18855325` on mainnet network via `https://nodes.sequence.app/mainnet` RPC endpoint and print the result in console formatted in columns with the same width:

```shell
ethkit block 18855325 -r https://nodes.sequence.app/mainnet --full
```

Retrieve the full block information for block `18855325` on mainnet network via `https://nodes.sequence.app/mainnet` RPC endpoint and print the result in console as a prettified JSON:

```shell
ethkit block 18855325 -r https://nodes.sequence.app/mainnet --full --json
```