### PR TITLE
fix un subscription deadlock

### DIFF
--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -987,9 +987,7 @@ func (m *Monitor) NumSubscribers() int {
 func (m *Monitor) UnsubscribeAll(err error) {
 	m.mu.Lock()
 	var subs []*subscriber
-	for _, sub := range m.subscribers {
-		subs = append(subs, sub)
-	}
+	subs = append(subs, m.subscribers...)
 	m.mu.Unlock()
 
 	for _, sub := range subs {

--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -994,7 +994,7 @@ func (m *Monitor) UnsubscribeAll(err error) {
 
 	for _, sub := range subs {
 		sub.err = err
-		sub.unsubscribe()
+		sub.Unsubscribe()
 	}
 }
 

--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -986,10 +986,15 @@ func (m *Monitor) NumSubscribers() int {
 
 func (m *Monitor) UnsubscribeAll(err error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	var subs []*subscriber
 	for _, sub := range m.subscribers {
+		subs = append(subs, sub)
+	}
+	m.mu.Unlock()
+
+	for _, sub := range subs {
 		sub.err = err
-		sub.Unsubscribe()
+		sub.unsubscribe()
 	}
 }
 


### PR DESCRIPTION
The previous `UnsubscribeAll` methods leads to dead lock. Because `Unsubscribe` method call lock internally. https://github.com/0xsequence/ethkit/blob/a65c80fc96cf8af8728e180aa5490f9a20666b91/ethmonitor/ethmonitor.go#L878

This PR will gather all the subscriber first in critical section then it unsubscribes in non critical section. 