### PR TITLE
harden ethmonitor for block header streaming errors

### DIFF
--- a/cmd/chain-watch/main.go
+++ b/cmd/chain-watch/main.go
@@ -65,6 +65,7 @@ func main() {
 	monitorOptions.PollingInterval = time.Duration(2000 * time.Millisecond)
 	monitorOptions.WithLogs = true
 	monitorOptions.BlockRetentionLimit = 64
+	monitorOptions.StreamingRetryAfter = 1 * time.Minute
 	// monitorOptions.StartBlockNumber = nil // track the head
 
 	latestBlock, err := provider.BlockByNumber(context.Background(), nil)

--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -30,7 +30,7 @@ var DefaultOptions = Options{
 	PollingInterval:                  1500 * time.Millisecond,
 	ExpectedBlockInterval:            15 * time.Second,
 	StreamingErrorResetInterval:      15 * time.Minute,
-	StreamingRetryAfter:              1 * time.Hour,
+	StreamingRetryAfter:              20 * time.Minute,
 	StreamingErrNumToSwitchToPolling: 3,
 	UnsubscribeOnStop:                false,
 	Timeout:                          20 * time.Second,
@@ -328,7 +328,7 @@ func (m *Monitor) listenNewHead() <-chan uint64 {
 			if err != nil {
 				m.log.Warnf("ethmonitor: websocket connect failed: %v", err)
 				m.alert.Alert(context.Background(), "ethmonitor: websocket connect failed", err)
-				time.Sleep(1500 * time.Millisecond)
+				time.Sleep(2000 * time.Millisecond)
 
 				streamingErrorLastTime = time.Now()
 				goto reconnect
@@ -383,6 +383,7 @@ func (m *Monitor) listenNewHead() <-chan uint64 {
 					case <-retryStreamingTimer.C:
 						// retry streaming
 						m.log.Info("ethmonitor: retrying streaming...")
+						streamingErrorLastTime = time.Now().Add(-m.options.StreamingErrorResetInterval * 2)
 						goto reconnect
 					default:
 						// non-blocking

--- a/ethmonitor/ethmonitor.go
+++ b/ethmonitor/ethmonitor.go
@@ -456,7 +456,7 @@ func (m *Monitor) monitor() error {
 			return nil
 
 		case newHeadNum := <-listenNewHead:
-			// ensure we
+			// ensure we have a new head number
 			m.nextBlockNumberMu.Lock()
 			if m.nextBlockNumber != nil && newHeadNum > 0 && m.nextBlockNumber.Uint64() > newHeadNum {
 				m.nextBlockNumberMu.Unlock()


### PR DESCRIPTION
1. The change switches ethmonitor from head streaming to poll if it encounters too many errors in a row.
2. The ethmonitor will restart the head streaming if block heads are not published in a timely manner.
3. The ethmonitor if in head poll mode will try to go back to head stream mode after specified time.

The change can be tested by setting up local nodegateway, pointing watch cmd at it and stoping/restarting node gateway service.