### PR TITLE
Handle "null" result from eth_getTransactionCount method

### DIFF
--- a/ethrpc/jsonrpc.go
+++ b/ethrpc/jsonrpc.go
@@ -127,6 +127,11 @@ func hexIntoBigInt(message json.RawMessage, ret **big.Int) error {
 }
 
 func hexIntoUint64(message json.RawMessage, ret *uint64) error {
+	if len(message) == 4 && string(message) == "null" {
+		*ret = 0
+		return nil
+	}
+
 	var result hexutil.Uint64
 	if err := json.Unmarshal(message, &result); err != nil {
 		return err
@@ -136,6 +141,11 @@ func hexIntoUint64(message json.RawMessage, ret *uint64) error {
 }
 
 func hexIntoUint(message json.RawMessage, ret *uint) error {
+	if len(message) == 4 && string(message) == "null" {
+		*ret = 0
+		return nil
+	}
+
 	var result hexutil.Uint
 	if err := json.Unmarshal(message, &result); err != nil {
 		return err


### PR DESCRIPTION
Fixes error: getting transaction count: json: cannot unmarshal non-string into Go value of type hexutil.Uint

Example payload:
```
curl -X 'POST' -d '{"jsonrpc":"2.0","id":20,"method":"eth_getBlockTransactionCountByHash","params":["0x75e20b44ed45bd9e8d261385fb2cb1886c31f91b8bafad9cc38addebf1f950ed"]}' -H 'Content-Type: application/json' -H 'User-Agent: sequence/node-check' 'https://little-crimson-energy.quiknode.pro/***/'

time: 13.592958ms
status: HTTP 200
body: {"jsonrpc":"2.0","id":20,"result":null}
```