### PR TITLE
ADD: base sepolia network

### DIFF
--- a/ethrpc/networks.go
+++ b/ethrpc/networks.go
@@ -132,6 +132,12 @@ var Networks = map[uint64]Network{
 		NumBlocksToFinality: 50,
 		OptimismChain:       true,
 	},
+	84532: {
+		Name:                "base-sepolia",
+		ChainID:             84532,
+		NumBlocksToFinality: 50,
+		OptimismChain:       true,
+	},
 	19011: {
 		Name:                "homeverse",
 		ChainID:             19011,


### PR DESCRIPTION
Base Sepolia appears to be the only base testnet supported by sequence now, and I wanted to use it.

Elected to add rather than remove the existing one in case it was  being kept for any reason.