### PR TITLE
ethwallet: swap out btcec.S256 with crypto.S256

### DIFF
--- a/ethwallet/hdnode.go
+++ b/ethwallet/hdnode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/accounts"
 	"github.com/0xsequence/ethkit/go-ethereum/common"
 	"github.com/0xsequence/ethkit/go-ethereum/crypto"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/tyler-smith/go-bip39"
@@ -249,6 +250,9 @@ func derivePrivateKey(masterKey *hdkeychain.ExtendedKey, path accounts.Derivatio
 	}
 
 	privateKeyECDSA := privateKey.ToECDSA()
+	if privateKeyECDSA.Curve == btcec.S256() {
+		privateKeyECDSA.PublicKey.Curve = crypto.S256()
+	}
 	return privateKeyECDSA, nil
 }
 


### PR DESCRIPTION
https://github.com/0xsequence/ethkit/blob/cdebd571052500fd2e341d7e91cdfd0bb128a6d9/go-ethereum/crypto/signature_nocgo.go#L82-L84 https://github.com/0xsequence/ethkit/blob/cdebd571052500fd2e341d7e91cdfd0bb128a6d9/go-ethereum/crypto/signature_nocgo.go#L161-L196

Upstream go-ethereum started embedding the original curve in a new type with custom marshaling, causing the original curve check to fail when running with CGO_ENABLED=0.