### PR TITLE
Temporary go-ethereum patch: Allow numbers with leading zeroes, e.g. …

### DIFF
--- a/go-ethereum/common/hexutil/hexutil.go
+++ b/go-ethereum/common/hexutil/hexutil.go
@@ -201,9 +201,11 @@ func checkNumber(input string) (raw string, err error) {
 	if len(input) == 0 {
 		return "", ErrEmptyNumber
 	}
-	if len(input) > 1 && input[0] == '0' {
-		return "", ErrLeadingZero
-	}
+	// Temporary Sequence patch.
+	// Uncommented to allow numbers with leading zeroes, e.g. 0x09.
+	// if len(input) > 1 && input[0] == '0' {
+	// 	return "", ErrLeadingZero
+	// }
 	return input, nil
 }
 

--- a/go-ethereum/common/hexutil/json.go
+++ b/go-ethereum/common/hexutil/json.go
@@ -403,9 +403,11 @@ func checkNumberText(input []byte) (raw []byte, err error) {
 	if len(input) == 0 {
 		return nil, ErrEmptyNumber
 	}
-	if len(input) > 1 && input[0] == '0' {
-		return nil, ErrLeadingZero
-	}
+	// Temporary Sequence patch.
+	// Uncommented to allow numbers with leading zeroes, e.g. 0x09.
+	// if len(input) > 1 && input[0] == '0' {
+	// 	return nil, ErrLeadingZero
+	// }
 	return input, nil
 }
 


### PR DESCRIPTION
…0x09