### PR TITLE
fix: fix slice init length

### DIFF
--- a/ethcoder/merkle_proof.go
+++ b/ethcoder/merkle_proof.go
@@ -142,7 +142,7 @@ func (mt *MerkleTree[TLeaf]) GetProof(leaf TLeaf) ([]Proof, error) {
 
 func (mt *MerkleTree[TLeaf]) GetHexProof(leaf TLeaf) [][]byte {
 	proof, _ := mt.GetProof(leaf)
-	hexProof := make([][]byte, len(proof))
+	hexProof := make([][]byte, 0, len(proof))
 	for _, p := range proof {
 		hexProof = append(hexProof, []byte(p.Data))
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `len(proof)`  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW