### PR TITLE
fix: allow empty addresses

### DIFF
--- a/ethcoder/typed_data.go
+++ b/ethcoder/typed_data.go
@@ -113,7 +113,7 @@ func (t TypedDataDomain) Map() map[string]interface{} {
 	if t.ChainID != nil {
 		m["chainId"] = t.ChainID
 	}
-	if t.VerifyingContract != nil && t.VerifyingContract.String() != "0x0000000000000000000000000000000000000000" {
+	if t.VerifyingContract != nil {
 		m["verifyingContract"] = *t.VerifyingContract
 	}
 	if t.Salt != nil {


### PR DESCRIPTION
This PR allows for empty addresses to be encoded for the `VerifyingContract` for EIP-712 domains

Needed to encode natively for workaround cases when hashing empty addresses in `v3`: https://github.com/0xsequence/sequence-v3/blob/74d5b40a13ba5106025fa936343f357c8a722e36/src/modules/auth/BaseSig.sol#L427