### PR TITLE
Minor improvements

### DIFF
--- a/cmd/ethkit/block.go
+++ b/cmd/ethkit/block.go
@@ -172,7 +172,7 @@ func NewHeader(b *types.Block) *Header {
 		WithdrawalsHash: b.Header().WithdrawalsHash,
 		Size:            b.Header().Size(),
 		// TotalDifficulty:  b.Difficulty(),
-		TransactionsHash: TransactionsHash(*b),
+		TransactionsHash: TransactionsHash(b),
 	}
 }
 
@@ -188,7 +188,7 @@ func (h *Header) String() string {
 }
 
 // TransactionsHash returns a list of transaction hash starting from a list of transactions contained in a block.
-func TransactionsHash(block types.Block) []common.Hash {
+func TransactionsHash(block *types.Block) []common.Hash {
 	txsh := make([]common.Hash, len(block.Transactions()))
 
 	for i, tx := range block.Transactions() {

--- a/cmd/ethkit/wallet.go
+++ b/cmd/ethkit/wallet.go
@@ -13,8 +13,9 @@ import (
 	"github.com/0xsequence/ethkit/ethwallet"
 	"github.com/0xsequence/ethkit/go-ethereum/accounts/keystore"
 	"github.com/0xsequence/ethkit/go-ethereum/common"
+
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func init() {
@@ -261,7 +262,7 @@ func fileExists(filename string) bool {
 
 func readSecretInput(prompt string) ([]byte, error) {
 	fmt.Print(prompt)
-	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return nil, err
 	}

--- a/ethcoder/ethcoder.go
+++ b/ethcoder/ethcoder.go
@@ -12,9 +12,7 @@ func BytesToBytes32(slice []byte) [32]byte {
 }
 
 func PaddedAddress(address string) string {
-	if strings.HasPrefix(address, "0x") {
-		address = address[2:]
-	}
+	address = strings.TrimPrefix(address, "0x")
 	if len(address) < 64 {
 		address = strings.Repeat("0", 64-len(address)) + address
 	}

--- a/ethcoder/solidity_pack.go
+++ b/ethcoder/solidity_pack.go
@@ -163,7 +163,7 @@ func solidityArgumentPack(typ string, val interface{}, isArray bool) ([]byte, er
 			return nil, fmt.Errorf("not a [%d]byte", size)
 		}
 
-		v := make([]byte, size, size)
+		v := make([]byte, size)
 		var ok bool
 		for i := 0; i < int(size); i++ {
 			v[i], ok = rv.Index(i).Interface().(byte)

--- a/ethreceipts/ethreceipts.go
+++ b/ethreceipts/ethreceipts.go
@@ -942,12 +942,11 @@ func groupLogsByTransaction(logs []types.Log) map[string][]*types.Log {
 	return out
 }
 
-func blockLogsCount(numTxns int, logs []types.Log) uint {
-	var max uint = uint(numTxns)
+// this is unused
+func blockLogsCount(numTxns int, logs []*types.Log) uint {
+	blockCount := uint(numTxns)
 	for _, log := range logs {
-		if log.TxIndex+1 > max {
-			max = log.TxIndex + 1
-		}
+		blockCount = max(blockCount, log.TxIndex+1)
 	}
-	return max
+	return blockCount
 }

--- a/go-ethereum/common/hexutil/json.go
+++ b/go-ethereum/common/hexutil/json.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/0xsequence/ethkit/util"
 	"github.com/holiman/uint256"
 )
 
@@ -45,6 +46,11 @@ func (b Bytes) MarshalText() ([]byte, error) {
 	copy(result, `0x`)
 	hex.Encode(result[2:], b)
 	return result, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b Bytes) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -159,6 +165,11 @@ func (b Big) MarshalText() ([]byte, error) {
 	return []byte(EncodeBig((*big.Int)(&b))), nil
 }
 
+// MarshalJSON implements json.Marshaler.
+func (b Big) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Big) UnmarshalJSON(input []byte) error {
 	if !isString(input) {
@@ -238,6 +249,11 @@ func (b U256) MarshalText() ([]byte, error) {
 	return []byte(u256.Hex()), nil
 }
 
+// MarshalJSON implements json.Marshaler.
+func (b U256) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *U256) UnmarshalJSON(input []byte) error {
 	// The uint256.Int.UnmarshalJSON method accepts "dec", "0xhex"; we must be
@@ -280,6 +296,11 @@ func (b Uint64) MarshalText() ([]byte, error) {
 	copy(buf, `0x`)
 	buf = strconv.AppendUint(buf, uint64(b), 16)
 	return buf, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b Uint64) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -341,6 +362,11 @@ type Uint uint
 // MarshalText implements encoding.TextMarshaler.
 func (b Uint) MarshalText() ([]byte, error) {
 	return Uint64(b).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b Uint) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/go-ethereum/common/math/big.go
+++ b/go-ethereum/common/math/big.go
@@ -20,6 +20,8 @@ package math
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/0xsequence/ethkit/util"
 )
 
 // Various big integer limit values.
@@ -78,6 +80,11 @@ func (i *HexOrDecimal256) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("%#x", (*big.Int)(i))), nil
 }
 
+// MarshalJSON implements json.Marshaler.
+func (i HexOrDecimal256) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(&i)
+}
+
 // Decimal256 unmarshals big.Int as a decimal string. When unmarshalling,
 // it however accepts either "0x"-prefixed (hex encoded) or non-prefixed (decimal)
 type Decimal256 big.Int
@@ -102,6 +109,11 @@ func (i *Decimal256) UnmarshalText(input []byte) error {
 // MarshalText implements encoding.TextMarshaler.
 func (i *Decimal256) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (i Decimal256) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(&i)
 }
 
 // String implements Stringer.

--- a/go-ethereum/common/math/integer.go
+++ b/go-ethereum/common/math/integer.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/bits"
 	"strconv"
+
+	"github.com/0xsequence/ethkit/util"
 )
 
 // Integer limit values.
@@ -65,6 +67,11 @@ func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
 // MarshalText implements encoding.TextMarshaler.
 func (i HexOrDecimal64) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("%#x", uint64(i))), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (i HexOrDecimal64) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(i)
 }
 
 // ParseUint64 parses s as an integer in decimal or hexadecimal syntax.

--- a/go-ethereum/common/types.go
+++ b/go-ethereum/common/types.go
@@ -211,7 +211,9 @@ func (h *UnprefixedHash) UnmarshalText(input []byte) error {
 
 // MarshalText encodes the hash as hex.
 func (h UnprefixedHash) MarshalText() ([]byte, error) {
-	return []byte(hex.EncodeToString(h[:])), nil
+	b := make([]byte, hex.EncodedLen(len(h)))
+	hex.Encode(b, h[:])
+	return b, nil
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -398,7 +400,9 @@ func (a *UnprefixedAddress) UnmarshalText(input []byte) error {
 
 // MarshalText encodes the address as hex.
 func (a UnprefixedAddress) MarshalText() ([]byte, error) {
-	return []byte(hex.EncodeToString(a[:])), nil
+	b := make([]byte, hex.EncodedLen(len(a)))
+	hex.Encode(b, a[:])
+	return b, nil
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/go-ethereum/common/types.go
+++ b/go-ethereum/common/types.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
+	"github.com/0xsequence/ethkit/util"
+
 	"golang.org/x/crypto/sha3"
 )
 
@@ -142,6 +144,11 @@ func (h Hash) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(h[:]).MarshalText()
 }
 
+// MarshalJSON implements json.Marshaler.
+func (h Hash) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(h)
+}
+
 // SetBytes sets the hash to the value of b.
 // If b is larger than len(h), b will be cropped from the left.
 func (h *Hash) SetBytes(b []byte) {
@@ -205,6 +212,11 @@ func (h *UnprefixedHash) UnmarshalText(input []byte) error {
 // MarshalText encodes the hash as hex.
 func (h UnprefixedHash) MarshalText() ([]byte, error) {
 	return []byte(hex.EncodeToString(h[:])), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (h UnprefixedHash) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(h)
 }
 
 /////////// Address
@@ -323,9 +335,14 @@ func (a *Address) SetBytes(b []byte) {
 	copy(a[AddressLength-len(b):], b)
 }
 
-// MarshalText returns the hex representation of a.
+// MarshalText returns the hex representation of the address.
 func (a Address) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(a[:]).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (a Address) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(a)
 }
 
 // UnmarshalText parses a hash in hex syntax.
@@ -382,6 +399,11 @@ func (a *UnprefixedAddress) UnmarshalText(input []byte) error {
 // MarshalText encodes the address as hex.
 func (a UnprefixedAddress) MarshalText() ([]byte, error) {
 	return []byte(hex.EncodeToString(a[:])), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (a UnprefixedAddress) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(a)
 }
 
 // MixedcaseAddress retains the original string, which may or may not be

--- a/go-ethereum/core/types/account.go
+++ b/go-ethereum/core/types/account.go
@@ -26,6 +26,8 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/common"
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
 	"github.com/0xsequence/ethkit/go-ethereum/common/math"
+
+	"github.com/0xsequence/ethkit/util"
 )
 
 //go:generate go run github.com/fjl/gencodec -type Account -field-override accountMarshaling -out gen_account.go
@@ -69,6 +71,11 @@ func (h *storageJSON) UnmarshalText(text []byte) error {
 
 func (h storageJSON) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(h[:]).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (h storageJSON) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(h)
 }
 
 // GenesisAlloc specifies the initial state of a genesis block.

--- a/go-ethereum/core/types/block.go
+++ b/go-ethereum/core/types/block.go
@@ -31,6 +31,8 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/common"
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
 	"github.com/0xsequence/ethkit/go-ethereum/rlp"
+
+	"github.com/0xsequence/ethkit/util"
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the
@@ -53,6 +55,11 @@ func (n BlockNonce) Uint64() uint64 {
 // MarshalText encodes n as a hex string with 0x prefix.
 func (n BlockNonce) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(n[:]).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b BlockNonce) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/go-ethereum/core/types/bloom9.go
+++ b/go-ethereum/core/types/bloom9.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
 	"github.com/0xsequence/ethkit/go-ethereum/crypto"
+	"github.com/0xsequence/ethkit/util"
 )
 
 type bytesBacked interface {
@@ -93,6 +94,11 @@ func (b Bloom) Test(topic []byte) bool {
 // MarshalText encodes b as a hex string with 0x prefix.
 func (b Bloom) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(b[:]).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b Bloom) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
 }
 
 // UnmarshalText b as a hex string with 0x prefix.

--- a/go-ethereum/crypto/crypto.go
+++ b/go-ethereum/crypto/crypto.go
@@ -257,8 +257,10 @@ func checkKeyFileEnd(r *bufio.Reader) error {
 // SaveECDSA saves a secp256k1 private key to the given file with
 // restrictive permissions. The key data is saved hex-encoded.
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
-	k := hex.EncodeToString(FromECDSA(key))
-	return os.WriteFile(file, []byte(k), 0600)
+	raw := FromECDSA(key)
+	k := make([]byte, hex.EncodedLen(len(raw)))
+	hex.Encode(k, raw)
+	return os.WriteFile(file, k, 0600)
 }
 
 // GenerateKey generates a new private key.

--- a/go-ethereum/crypto/kzg4844/kzg4844.go
+++ b/go-ethereum/crypto/kzg4844/kzg4844.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
+	"github.com/0xsequence/ethkit/util"
 )
 
 //go:embed trusted_setup.json
@@ -49,6 +50,11 @@ func (b Blob) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(b[:]).MarshalText()
 }
 
+// MarshalJSON implements json.Marshaler.
+func (b Blob) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(b)
+}
+
 // Commitment is a serialized commitment to a polynomial.
 type Commitment [48]byte
 
@@ -62,6 +68,11 @@ func (c Commitment) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(c[:]).MarshalText()
 }
 
+// MarshalJSON implements json.Marshaler.
+func (c Commitment) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(c)
+}
+
 // Proof is a serialized commitment to the quotient polynomial.
 type Proof [48]byte
 
@@ -73,6 +84,11 @@ func (p *Proof) UnmarshalJSON(input []byte) error {
 // MarshalText returns the hex representation of p.
 func (p Proof) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(p[:]).MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (p Proof) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(p)
 }
 
 // Point is a BLS field element.

--- a/go-ethereum/rpc/types.go
+++ b/go-ethereum/rpc/types.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/0xsequence/ethkit/go-ethereum/common"
 	"github.com/0xsequence/ethkit/go-ethereum/common/hexutil"
+
+	"github.com/0xsequence/ethkit/util"
 )
 
 // API describes the set of methods offered over the RPC interface
@@ -121,6 +123,11 @@ func (bn BlockNumber) Int64() int64 {
 // - other numbers as hex
 func (bn BlockNumber) MarshalText() ([]byte, error) {
 	return []byte(bn.String()), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (bn BlockNumber) MarshalJSON() ([]byte, error) {
+	return util.QuoteString(bn)
 }
 
 func (bn BlockNumber) String() string {

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/net v0.39.0
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.32.0
+	golang.org/x/term v0.31.0
 	golang.org/x/tools v0.31.0
 )
 
@@ -64,7 +65,6 @@ require (
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/util/quote.go
+++ b/util/quote.go
@@ -1,0 +1,14 @@
+package util
+
+import "encoding"
+
+// QuoteString adds quotes to the byte slice returned by the TextMarshaler.
+func QuoteString(b encoding.TextMarshaler) ([]byte, error) {
+	raw, err := b.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	raw = append([]byte{'"'}, raw...)
+	raw = append(raw, '"')
+	return raw, nil
+}


### PR DESCRIPTION
- Update deprecated terminal package
- Simplify `PaddedAddress` function by using `TrimPrefix`
- Update `blockLogsCount` function to use builtin `max`
- Simplify byte slice creation in `solidityArgumentPack` function
- Implement JSON marshaling for various types using `QuoteString` utility
- Avoid `byte->string->byte` conversion in hex encoding in `MarshalText` and `SaveECDSA` functions
- Change `TransactionsHash` function to accept a pointer to types.Block since it has atomic values