### PR TITLE
fix: dereference error in UnmarshalJSON for BatchCall

### DIFF
--- a/ethrpc/batch.go
+++ b/ethrpc/batch.go
@@ -39,7 +39,7 @@ func (b *BatchCall) UnmarshalJSON(data []byte) error {
 	for i, msg := range results {
 		(*b)[i].response = msg
 		if msg.Error != nil {
-			(*b)[i].err = msg.Error
+			(*b)[i].err = *msg.Error
 		}
 	}
 	return nil


### PR DESCRIPTION
While testing some endpoints I found that I could not use `errors.As` with `jsonrpc.Error` consistently. After some debugging I found the cause: in some parts `jsonrpc.Error` is returned, while `BatchCall` uses `*jsonrpc.Error`. 

This PR makes the type consistent.

This:
```go
func handleRPCError(t *testing.T, err error) {
	if jsonErr := (&jsonrpc.Error{}); errors.As(err, jsonErr) || errors.As(err, &jsonErr) {
		if jsonErr.Code == -32000 {
			t.Skipf("skipping: %s", err)
		}
	}
}
```
Becomes:
```go
func handleRPCError(t *testing.T, err error) {
	if jsonErr := (&jsonrpc.Error{}); errors.As(err, jsonErr) {
		if jsonErr.Code == -32000 {
			t.Skipf("skipping: %s", err)
		}
	}
}
```
