### PR TITLE
ethrpc: preserve non-batch errors in BatchCall

### DIFF
--- a/ethrpc/multicall.go
+++ b/ethrpc/multicall.go
@@ -158,8 +158,8 @@ func (p *Provider) BatchCall(ctx context.Context, calls []multicall.Call, option
 
 	_, err := p.Do(ctx, calls_...)
 	if err != nil {
-		if err, ok := err.(BatchError); ok {
-			for i, err := range err.ErrorMap() {
+		if batchErr, ok := err.(BatchError); ok {
+			for i, err := range batchErr.ErrorMap() {
 				if err != nil {
 					if calls[i].AllowFailure {
 						if revertData, ok := revertDataFromError(err); ok {

--- a/ethrpc/multicall_unit_test.go
+++ b/ethrpc/multicall_unit_test.go
@@ -1,0 +1,34 @@
+package ethrpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/0xsequence/ethkit/ethrpc/multicall"
+)
+
+type failingHTTPClient struct {
+	err error
+}
+
+func (c failingHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return nil, c.err
+}
+
+func TestBatchCallPreservesTransportError(t *testing.T) {
+	transportErr := errors.New("transport unavailable")
+	provider, err := NewProvider(
+		"http://example.invalid",
+		WithHTTPClient(failingHTTPClient{err: transportErr}),
+	)
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+
+	_, _, err = provider.BatchCall(context.Background(), []multicall.Call{{}})
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("BatchCall() error = %v, want it to wrap %v", err, transportErr)
+	}
+}


### PR DESCRIPTION
Preserve the original error returned by `Provider.Do` when `BatchCall` receives an error that is not a `BatchError`.

The previous type assertion reused the name `err`:

```go
if err, ok := err.(BatchError); ok {
```

When the assertion failed, the else branch referred to the zero value produced by the failed assertion instead of the original error. This resulted in an empty error such as:

`unable to batch call:`

It also prevented callers from inspecting the underlying error with errors.Is.

The asserted value is now named batchErr, allowing the non-batch branch to wrap the original error. Existing BatchError handling remains unchanged.

A regression test uses a failing HTTP client to verify that the transport error remains in the returned error chain.